### PR TITLE
ci: monitor build processes with build-process-watcher

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,11 @@ jobs:
 
           - name: Setup Gradle
             uses: gradle/actions/setup-gradle@v5
+          - name: Build Process Watcher
+            uses: cdsap/build-process-watcher@v0.6.2
+            with:
+                remote_monitoring: 'true'
+                export_to_bigquery: 'true'
           - name: Execute Gradle build
             run:  ./gradlew test
     fatbinary:
@@ -40,6 +45,11 @@ jobs:
 
             - name: Setup Gradle
               uses: gradle/actions/setup-gradle@v5
+            - name: Build Process Watcher
+              uses: cdsap/build-process-watcher@v0.6.2
+              with:
+                  remote_monitoring: 'true'
+                  export_to_bigquery: 'true'
             - name: Execute Gradle build
               run:  |
                 ./gradlew :cli:fatBinary


### PR DESCRIPTION
Adds the [`cdsap/build-process-watcher@v0.6.2`](https://github.com/cdsap/build-process-watcher) GitHub Action as a step before the Gradle invocations in the existing **assemble** and **fatbinary** jobs.

It monitors the Java/Kotlin build processes (GradleDaemon, GradleWorkerMain, KotlinCompileDaemon) — memory, GC, JIT, class loading — without Java agent injection or JVM arg changes.

Enabled options:
- `remote_monitoring: 'true'` — remote execution / cloud dashboard
- `export_to_bigquery: 'true'` — export this run's samples to BigQuery

The action starts background monitoring and finalizes in its post step, so it's placed right before each `./gradlew` invocation.