### PR TITLE
docs: rename Gradle Enterprise references to Develocity

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,9 +134,9 @@ cd cli
 | Name       | Description                              | Default | Required | Example                         |
 |------------|------------------------------------------|---------|----------|---------------------------------|
 | api-key    | String token                             |         | Yes      | --api-key=$DV_KEY               |
-| url        | Gradle Enterprise instance               |         | Yes      | --url=https://ge.acme.dev       |
+| url        | Develocity instance                      |         | Yes      | --url=https://ge.acme.dev       |
 | max-builds | Max builds to be processed               | 100     | No       | --max-builds=500                |
-| project    | Root project in Gradle Enterprise        |         | Yes      | --project=acme                  |
+| project    | Root project in Develocity               |         | Yes      | --project=acme                  |
 | tags       | One or more tags included in the build.  |         | No       | --tags=main --tags=not:local    |
 | user       | Author of the build                      |         | No       | --user=leo                      |
 
@@ -145,7 +145,7 @@ cd cli
 | Name          | Description                | Default | Required | Example                   |
 |---------------|----------------------------|---------|----------|---------------------------|
 | api-key       | String token               |         | Yes      | --api-key=$DV_KEY         |
-| url           | Gradle Enterprise instance |         | Yes      | --url=https://ge.acme.dev |
+| url           | Develocity instance        |         | Yes      | --url=https://ge.acme.dev |
 | build-scan-id | Build scan id              |         | Yes      | --build-scan-id=iwuduw8   |
 
 ## Dependency


### PR DESCRIPTION
Renames the user-facing `Gradle Enterprise` references in the README CLI parameter tables to the current product name **Develocity**:

- `url` description: "Gradle Enterprise instance" → "Develocity instance" (both the aggregate and single-build tables)
- `project` description: "Root project in Gradle Enterprise" → "Root project in Develocity"

Code references to `GradleEnterpriseRepository` / `GEClient` are left as-is — those are types from the external `geapi-data` dependency, which currently exposes no Develocity-named equivalents.