### PR TITLE
Release 0.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ org.jetbrains.kotlin.gradle.internal.transforms.ClasspathEntrySnapshotTransform,
 #### Using Binary
 Github release repository contains the ArtifactTransformReport binary. After downloading the binary you can execute:
 ```
- curl -L https://github.com/cdsap/ArtifactTransformReport/releases/download/v0.1.1/artifacttransform --output artifacttransform
+ curl -L https://github.com/cdsap/ArtifactTransformReport/releases/download/v0.2.0/artifacttransform --output artifacttransform
  chmod 0757 artifacttransform
 ./artifacttransform --api-key=$KEY --url=$URL --project nowinandroid
 ```
@@ -165,7 +165,7 @@ cd cli
 
 If you don't want to use the CLI, we are providing a dependency to retrieve the Artifact transforms:
 ```kotlin
-implementation("io.github.cdsap:artifacttransform:0.1")
+implementation("io.github.cdsap:artifacttransform:0.2.0")
 ```
 ### Usage
 Retrieve artifact transforms of the last 50 builds of the project nowinandroid:

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = "io.github.cdsap"
-version = "0.1"
+version = "0.2.0"
 
 dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.11.0")
@@ -27,7 +27,7 @@ configure<JavaPluginExtension> {
 mavenPublishing {
     publishToMavenCentral()
     signAllPublications()
-    coordinates("io.github.cdsap", "artifacttransform", "0.1")
+    coordinates("io.github.cdsap", "artifacttransform", "0.2.0")
 
     pom {
         scm {


### PR DESCRIPTION
## Release 0.2.0

Prepares the `0.2.0` release. This branch brings the full Tier-1 artifact-transform analytics work to `main`, plus the version bump.

### Highlights
- **Tier-1 transform analytics** — cache effectiveness, changed-attribute transitions, per-build-scan aggregation, distribution measures (avg/p95/max/median), source attribution (module/dependency), dependency-family fragmentation, build-level analytics + outlier detection.
- **Interactive offline HTML report** — self-contained (Chart.js inlined), with the inferred artifact-transform pipeline graph and a full set of charts.
- **Negative avoidance savings section** (new) — per-transform-type table of transforms where reusing the cached output cost more than re-executing it; hidden when there are none. `formatMsValue` now signs/unit-converts negatives.
- **CI** — fatbinary e2e job verifies the HTML report is generated.

### Version bump
- `library` version + Maven coordinates → `0.2.0`
- README binary download URL → `v0.2.0`, dependency coordinate → `0.2.0`

### Cutting the release
Once merged, pushing the `v0.2.0` tag triggers `release.yml` (builds the fat binary and publishes the GitHub release asset).

### Note
`ktlintMainSourceSetCheck` is currently red on this line (pre-existing). `release.yml` only runs `:cli:fatBinary`, so it is unaffected, but a full `./gradlew build` will fail on lint until that is addressed.